### PR TITLE
Add Rate Limiting Support

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,3 +1,4 @@
+import { rateLimitTables } from "convex-helpers/server/rateLimit";
 import { Table } from "convex-helpers/server";
 import { defineSchema } from "convex/server";
 import { v } from "convex/values";
@@ -50,6 +51,7 @@ export const Settings = Table("settings", {
 });
 
 export default defineSchema({
+  ...rateLimitTables,
   actionItems: ActionItems.table
     .index("by_user", ["userId"])
     .index("by_note", ["noteId"]),

--- a/convex/utils.ts
+++ b/convex/utils.ts
@@ -1,5 +1,6 @@
 import type { Auth } from "convex/server";
 
+import { defineRateLimits } from "convex-helpers/server/rateLimit";
 import { ConvexError } from "convex/values";
 import { pick, pickBy } from "lodash";
 
@@ -47,6 +48,8 @@ export const mutateWithUser = customMutation(
  * @param fields The fields to pick
  * @returns The object with the specified fields and undefined values removed.
  */
+
+// biome-ignore lint/suspicious/noExplicitAny: <explanation>
 export const sanitizeInput = <T extends Record<string, any>>(
   input: T,
   fields: Array<keyof T>
@@ -56,3 +59,11 @@ export const sanitizeInput = <T extends Record<string, any>>(
     [K in keyof T as T[K] extends undefined ? never : K]: T[K];
   };
 };
+
+const SECOND = 1000; // ms
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+
+export const { checkRateLimit, rateLimit, resetRateLimit } = defineRateLimits({
+  whisper: { kind: "fixed window", rate: 100, period: HOUR },
+});


### PR DESCRIPTION
### TL;DR
Added rate limiting functionality to the application using convex-helpers.

### What changed?
- Integrated rate limiting tables into the schema
- Added rate limit configuration for whisper functionality (100 requests per hour)
- Implemented utility functions for checking, applying, and resetting rate limits

### How to test?
1. Make multiple whisper requests in quick succession
2. Verify that requests are blocked after exceeding 100 requests within an hour
3. Wait for an hour and confirm that the rate limit resets

### Why make this change?
To prevent abuse and ensure fair usage of the whisper functionality by implementing request rate limiting. This helps maintain service stability and protects against potential DoS attacks.