### PR TITLE
Add Notes Empty State UI

### DIFF
--- a/src/app/(console)/dashboard/_components/no-content.tsx
+++ b/src/app/(console)/dashboard/_components/no-content.tsx
@@ -1,0 +1,37 @@
+import { Text } from "@/components/ui/typography";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { PlusIcon } from "lucide-react";
+
+interface NoContentProps {
+	data: {
+		textHeading: string;
+		textBody: string;
+	};
+	handleCreate: () => void;
+}
+
+export function NoContent({ handleCreate, data }: NoContentProps) {
+	return (
+		<Card className="bg-transparent flex flex-col text-center max-w-md items-center border p-6 rounded-md border-dashed shadow-none h-min mt-32 border-neutral-400 dark:border-neutral-800">
+			<Text variant="h4" as="h4" className="">
+				{data.textHeading}
+			</Text>
+			<Text variant="p" as="span" className="!mt-1 text-sm mb-6">
+				{data.textBody}
+			</Text>
+			<Button
+				className="aspect-square max-sm:p-0 w-min rounded-lg"
+				onClick={handleCreate}
+				variant="outline"
+			>
+				<PlusIcon
+					className="opacity-60 sm:-ms-1"
+					aria-hidden="true"
+					size={16}
+				/>
+				<span className="max-sm:sr-only">Create Note</span>
+			</Button>
+		</Card>
+	);
+}

--- a/src/app/(console)/dashboard/_components/notes.tsx
+++ b/src/app/(console)/dashboard/_components/notes.tsx
@@ -1,7 +1,16 @@
+import { NoContent } from "@/app/(console)/dashboard/_components/no-content";
+
+const textHeading = "You haven't created any notes yet.";
+const textBody = "Start creating your first note.";
+
 export const Notes = () => {
+	const handleCreate = () => {
+		console.log("handleCreate");
+	};
+
 	return (
-		<p className="text-muted-foreground p-4 pt-1 text-center text-xs">
-			Content for Tab 3
-		</p>
+		<div className="bg-slate-100 dark:bg-zinc-950 rounded-md min-h-[calc(100vh_-_theme(spacing.64))] p-4 flex justify-center">
+			<NoContent data={{ textHeading, textBody }} handleCreate={handleCreate} />
+		</div>
 	);
 };


### PR DESCRIPTION
### TL;DR
Added a new "No Content" state component for the dashboard's notes section.

### What changed?
- Created a new `NoContent` component that displays when no notes exist
- Updated the Notes component to use the new `NoContent` state
- Added a placeholder create handler function
- Implemented responsive styling for both desktop and mobile views

### How to test?
1. Navigate to the dashboard
2. Go to the Notes tab
3. Verify the empty state shows:
   - "You haven't created any notes yet" heading
   - "Start creating your first note" subtext
   - A create button that's square on mobile and shows "Create Note" text on desktop

### Why make this change?
To provide users with clear feedback when they have no notes and guide them towards creating their first note, improving the overall user experience and reducing potential confusion about empty states.