### PR TITLE
Add Published Note Status and Filtering

### DIFF
--- a/convex/notes.ts
+++ b/convex/notes.ts
@@ -8,6 +8,7 @@ import { Notes } from "./schema";
 enum NoteStatusEnum {
   DRAFT = "draft",
   ARCHIVED = "archived",
+  PUBLISHED = "published",
 }
 
 export const getOneByUser = queryWithUser({

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -36,7 +36,11 @@ export const Notes = Table("notes", {
   generatingActionItems: v.boolean(),
   transcription: v.optional(v.string()),
   embedding: v.optional(v.array(v.float64())),
-  status: v.union(v.literal("draft"), v.literal("archived")),
+  status: v.union(
+    v.literal("draft"),
+    v.literal("archived"),
+    v.literal("published")
+  ),
 });
 
 export const ActionItems = Table("actionItems", {

--- a/src/app/(console)/dashboard/_components/notes.tsx
+++ b/src/app/(console)/dashboard/_components/notes.tsx
@@ -15,6 +15,7 @@ const filterOptions = { defaultValue: FilterOptions.ALL };
 
 const lists = [
 	{ value: FilterOptions.ALL, label: "All" },
+	{ value: FilterOptions.PUBLISHED, label: "Published" },
 	{ value: FilterOptions.DRAFT, label: "Draft" },
 	{ value: FilterOptions.ARCHIVED, label: "Archived" },
 ];
@@ -24,6 +25,7 @@ const filterNotes = (status: NoteStatus) =>
 		all: (note: Note) => !!note,
 		draft: (note: Note) => note.status === FilterOptions.DRAFT,
 		archived: (note: Note) => note.status === FilterOptions.ARCHIVED,
+		published: (note: Note) => note.status === FilterOptions.PUBLISHED,
 	})[status];
 
 const textHeading = "You haven't created any notes yet.";

--- a/src/model/constant.ts
+++ b/src/model/constant.ts
@@ -6,7 +6,7 @@ import {
   type AppState,
   type Note,
   DashboardTabs,
-  Themes
+  Themes,
 } from "@/model/types";
 
 import { Languages } from "@/lib/constants";
@@ -32,15 +32,13 @@ export const APPSTATE: AppState = {
 export const DASHBOARDSTATE: DashboardState = {
   loading: false,
   error: null,
-  dateRange: {
-    from: new Date(),
-    to: new Date()
-  },
-  activeTab: DashboardTabs.OVERVIEW
+  activeTab: DashboardTabs.OVERVIEW,
+  dateRange: { from: new Date(), to: new Date() },
 };
 
 export const FilterOptions = {
-	ALL: "all",
-	DRAFT: "draft",
-	ARCHIVED: "archived",
+  ALL: "all",
+  DRAFT: "draft",
+  ARCHIVED: "archived",
+  PUBLISHED: "published",
 } as const;

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -5,8 +5,8 @@ import type { DateRange } from "react-day-picker";
 export type NoteVersion = "v1" | "v2";
 export type AppStateVersion = "v1" | "v2";
 
-export type NoteStatus = "draft" | "archived";
-export type NoteFilter = "all" | NoteStatus;
+export type NoteStatus = "draft" | "archived" | "published";
+export type NoteFilterList = "all" | NoteStatus;
 
 export type DashboardTabs =
   | "overview"


### PR DESCRIPTION
### TL;DR

Added a new "published" status for notes to enhance the note lifecycle management.

### What changed?

- Added a new "published" status to the `NoteStatusEnum` in `convex/notes.ts`
- Updated the schema in `convex/schema.ts` to include "published" as a valid note status
- Added a new filter option for "Published" notes in the dashboard UI
- Updated the `FilterOptions` constant to include the new "published" status
- Modified the `NoteStatus` type to include the new status option

### How to test?

1. Create a new note and verify you can change its status to "published"
2. Navigate to the dashboard and confirm the "Published" filter appears in the filter dropdown
3. Set a note to "published" status and verify it appears when filtering by "Published"
4. Ensure existing functionality for "Draft" and "Archived" notes still works correctly

### Why make this change?

This change introduces a complete note lifecycle by adding a "published" state, allowing users to distinguish between notes that are works in progress (drafts), completed and shared (published), or no longer needed (archived). This provides a more intuitive workflow for managing notes throughout their lifecycle.