### PR TITLE
Add breadcrumb navigation to site header

### DIFF
--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -1,9 +1,31 @@
+"use client";
+
 import { ThemeSelector } from "@/components/theme/theme-selector";
 import { ModeToggle } from "@/components/theme/mode-toggle";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import { Separator } from "@/components/ui/separator";
+import { usePathname } from "next/navigation";
+import { pathGroup } from "@/lib/constants";
+import { Fragment } from "react";
+
+import {
+  BreadcrumbSeparator,
+  BreadcrumbItem,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbLink,
+  Breadcrumb,
+} from "@/components/ui/breadcrumb";
+
+const allowedPaths = Object.values(pathGroup).map((item) => item.path);
 
 export function SiteHeader() {
+  const pathname = usePathname();
+
+  const segmentedPaths = pathname.split("/").filter(Boolean);
+  const showBreadcrumb = allowedPaths.includes(segmentedPaths[0]);
+  const finalPath = segmentedPaths.pop();
+
   return (
     <header className="flex h-(--header-height) shrink-0 items-center gap-2 border-b transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-(--header-height)">
       <div className="flex w-full items-center gap-1 px-4 lg:gap-2 lg:px-6">
@@ -12,7 +34,26 @@ export function SiteHeader() {
           orientation="vertical"
           className="mx-2 data-[orientation=vertical]:h-4"
         />
-        <h1 className="text-base font-medium">Documents</h1>
+        {showBreadcrumb && (
+          <Breadcrumb>
+            <BreadcrumbList>
+              {segmentedPaths.map((item) => (
+                <Fragment key={item}>
+                  <BreadcrumbItem className="hidden md:block capitalize">
+                    <BreadcrumbLink href="#">
+                      {pathGroup[item].label}
+                    </BreadcrumbLink>
+                  </BreadcrumbItem>
+                  <BreadcrumbSeparator className="hidden md:block" />
+                </Fragment>
+              ))}
+
+              <BreadcrumbItem key={finalPath} className="capitalize">
+                <BreadcrumbPage>{finalPath}</BreadcrumbPage>
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
+        )}
         <div className="ml-auto flex items-center gap-2">
           <ModeToggle />
           <ThemeSelector />

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -15,6 +15,7 @@ import type {
   RecentSaleType,
   NavItemMapType,
   NavItemType,
+  PathGroup,
   Language,
   UseCase,
   Product,
@@ -390,3 +391,15 @@ export const chartData = [
 
 export const COOKIE_NAME = "active-theme";
 export const DEFAULT_THEME = "default";
+
+export const pathGroup: PathGroup = {
+  dashboard: { label: "Dashboard", hasChildRoute: true, path: "dashboard" },
+  notes: { label: "Notes", hasChildRoute: true, path: "notes" },
+  hume: { label: "Hume AI", hasChildRoute: false, path: "hume" },
+  elevenlabs: {
+    label: "ElevenLabs AI",
+    hasChildRoute: false,
+    path: "elevenlabs",
+  },
+  settings: { label: "Settings", hasChildRoute: true, path: "settings" },
+};

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -48,3 +48,7 @@ export type RecentSaleType = {
   alt: string;
   fallback: string;
 };
+
+export type PathGroup = {
+  [key: string]: { label: string; hasChildRoute: boolean; path: string };
+};


### PR DESCRIPTION
### TL;DR

Added breadcrumb navigation to the site header that dynamically displays the current path.

### What changed?

- Made `SiteHeader` a client component by adding the "use client" directive
- Implemented breadcrumb navigation that replaces the static "Documents" title
- Added path tracking using `usePathname()` from Next.js
- Created a new `pathGroup` constant in `constants.ts` to define allowed paths and their labels
- Added a new `PathGroup` type definition
- Breadcrumbs are only shown for paths defined in the `allowedPaths` array
- Made breadcrumbs responsive (hidden on mobile screens)

### How to test?

1. Navigate to different sections of the application (dashboard, notes, settings, etc.)
2. Verify that the breadcrumb navigation correctly displays the current path
3. Check that breadcrumbs are properly capitalized
4. Test responsiveness by viewing on mobile screens (breadcrumbs should be hidden)
5. Ensure that only paths defined in `pathGroup` show breadcrumbs

### Why make this change?

Improves user navigation by providing visual context of the current location within the application hierarchy. This helps users understand where they are in the site structure and provides an easy way to navigate back to parent sections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The site header now displays a dynamic breadcrumb navigation based on your current location, making it easier to understand and navigate the app’s structure.
- **Style**
  - Breadcrumb items are styled with responsive visibility for improved usability across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->